### PR TITLE
Support Windows OS by using findstr for grep feature.

### DIFF
--- a/lib/finder/grep.js
+++ b/lib/finder/grep.js
@@ -16,7 +16,7 @@
 var spawn = require('child_process').spawn;
 var path = require('path');
 var carrier = require('carrier');
-
+var os = require('os'), isWin = (os.platform() === 'win32');
 
 /**
  * A regular expression for parsing goog.provide results from grep output.
@@ -74,7 +74,7 @@ GrepFileFinder.prototype.prepopulate_ = function(options) {
  */
 GrepFileFinder.prototype.searchDir_ = function(dir) {
   // TODO: Track when done prepopulating, defer calls that come in before done.
-  var search = spawn('grep', ['-R', '--include=*.js', '^goog.provide(', dir]);
+  var search = isWin ? spawn('findstr', ['/S', '/R', '/C:^goog.provide(', '*.js', '/D:' + dir]) : spawn('grep', ['-R', '--include=*.js', '^goog.provide(', dir]);
   search.stdout.setEncoding('utf8');
   carrier.carry(search.stdout, function(line) {
     var match = line.match(PROVIDE_RE);
@@ -84,7 +84,7 @@ GrepFileFinder.prototype.searchDir_ = function(dir) {
     }
     var name = match[2];
     // Use the absolute path, unless under the project dir.
-    var filePath = path.resolve(dir, match[1]);
+    var filePath = isWin ? match[1] : path.resolve(dir, match[1]);
     if (filePath.indexOf(this.projectDir_) === 0) {
       filePath = path.relative(this.projectDir_, filePath);
     }


### PR DESCRIPTION
This PR gives the capability to use tern-closure with Windows OS (tested With Windows 7 64 bits) by using findstr (instead of using grep) inside grep.js if OS is Windows.
