### PR TITLE
Fix test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "closure"
   ],
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "mocha"
   },
   "author": "Josh Giles <joshgiles@google.com>"
 }


### PR DESCRIPTION
mocha no longer needs node_modules path, also this makes npm test work
on a windows msys environment. 

see a similar fix here: https://github.com/amber-smalltalk/amber/pull/406
